### PR TITLE
Add CMake detection for elfutils

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,85 @@
+parse:
+  additional_commands:
+    dyninst_library:
+      flags:
+      - BUILD_SHARED
+      - BUILD_STATIC
+      kwargs:
+        HEADERS: '*'
+        SOURCES: '*'
+        DEPENDS: '*'
+        COMPILE_DEFINITIONS: '*'
+        COMPILE_FEATURES: '*'
+        COMPILE_OPTIONS: '*'
+        DESTINATION: '*'
+        DEFAULT_VISIBILITY: '*'
+        INCLUDE_DIRECTORIES: '*'
+        LINK_LIBRARIES: '*'
+        LINK_OPTIONS: '*'
+        PROPERTIES: '*'
+    dyninst_add_cache_option:
+      kwargs:
+        CACHE: '*'
+  override_spec: {}
+  vartags: []
+  proptags: []
+format:
+  disable: false
+  line_width: 90
+  tab_size: 2
+  use_tabchars: false
+  fractional_tab_policy: use-space
+  max_subgroups_hwrap: 2
+  max_pargs_hwrap: 6
+  max_rows_cmdline: 2
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  dangle_parens: false
+  dangle_align: child
+  min_prefix_chars: 4
+  max_prefix_chars: 10
+  max_lines_hwrap: 2
+  line_ending: unix
+  command_case: lower
+  keyword_case: upper
+  always_wrap: []
+  enable_sort: true
+  autosort: false
+  require_valid_layout: false
+  layout_passes: {}
+markup:
+  bullet_char: '-'
+  enum_char: '*'
+  first_comment_is_literal: true
+  literal_comment_pattern: ^#
+  fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
+  ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
+  explicit_trailing_pattern: '#<'
+  hashruler_min_length: 10
+  canonicalize_hashrulers: true
+  enable_markup: false
+lint:
+  disabled_codes: []
+  function_pattern: '[0-9a-z_]+'
+  macro_pattern: '[0-9A-Z_]+'
+  global_var_pattern: '[A-Z][0-9A-Z_]+'
+  internal_var_pattern: _[A-Z][0-9A-Z_]+
+  local_var_pattern: '[a-z][a-z0-9_]+'
+  private_var_pattern: _[0-9a-z_]+
+  public_var_pattern: '[A-Z][0-9A-Z_]+'
+  argument_var_pattern: '[a-z][a-z0-9_]+'
+  keyword_pattern: '[A-Z][0-9A-Z_]+'
+  max_conditionals_custom_parser: 2
+  min_statement_spacing: 1
+  max_statement_spacing: 2
+  max_returns: 6
+  max_branches: 12
+  max_arguments: 5
+  max_localvars: 15
+  max_statements: 50
+encode:
+  emit_byteorder_mark: false
+  input_encoding: utf-8
+  output_encoding: utf-8
+misc:
+  per_command: {}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(UNIT_TESTS_INCLUDES ${DYNINST_SOURCE_TREE})
 
 set(UNIT_TESTS_WARNING_FLAGS -Wall -Wextra -pedantic)
 
+list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake"
+     "${PROJECT_SOURCE_DIR}/cmake/tpls" "${PROJECT_SOURCE_DIR}/cmake/Modules")
+
+include(DyninstElfUtils)
+
 enable_testing()
 
 add_subdirectory(dwarf)

--- a/cmake/Modules/FindElfutils.cmake
+++ b/cmake/Modules/FindElfutils.cmake
@@ -1,0 +1,133 @@
+#[=======================================================================[.rst:
+FindElfutils
+------------
+
+Find elfutils, a collection of utilities and libraries to read, create
+and modify ELF binary files, find and handle DWARF debug data,
+symbols, thread state and stacktraces for processes and core files
+on GNU/Linux.
+
+Variables that affect this module
+
+``ElfUtils_NO_SYSTEM_PATHS``
+  If `True`, no system paths are searched.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target:
+
+``Elfutils::Elfutils``
+  The elfutils library, if found.
+
+This module will set the following variables in your project:
+
+``Elfutils_INCLUDE_DIRS``
+  where to find elfutils headers
+``Elfutils_LIBRARIES``
+  the libraries to link against to use elfutils.
+``Elfutils_FOUND``
+  If false, do not try to use elfutils.
+``Elfutils_VERSION``
+  the version of the elfutils library found
+
+Support for libdebuginfod can be added by specifying it in ``COMPONENTS``.
+
+.. code-block:: cmake
+
+   find_package(Elfutils 0.186 EXACT REQUIRED COMPONENTS debuginfod)
+
+#]=======================================================================]
+cmake_policy(SET CMP0074 NEW) # Use <Package>_ROOT
+
+if(${Elfutils_FIND_REQUIRED})
+  set(_required "REQUIRED")
+endif()
+
+if(${Elfutils_FIND_QUIETLY})
+  set(_quiet "QUIET")
+endif()
+
+if(${Elfutils_FIND_EXACT})
+  set(_exact "EXACT")
+endif()
+
+# Propagate ElfUtils_NO_SYSTEM_PATHS
+foreach(_n "LibELF" "LibDW" "LibDebuginfod")
+  set(${_n}_NO_SYSTEM_PATHS ${ElfUtils_NO_SYSTEM_PATHS})
+  mark_as_advanced(${_n}_NO_SYSTEM_PATHS)
+
+  # Force the search directory
+  if(ElfUtils_NO_SYSTEM_PATHS)
+    set(${_n}_ROOT ${ElfUtils_ROOT_DIR})
+    mark_as_advanced(${_n}_ROOT)
+  endif()
+endforeach()
+
+find_package(LibELF ${Elfutils_FIND_VERSION} ${_exact} ${_required} ${_quiet})
+find_package(LibDW ${Elfutils_FIND_VERSION} ${_exact} ${_required} ${_quiet})
+
+if(NOT "x${Elfutils_FIND_COMPONENTS}" STREQUAL "x")
+  string(TOUPPER ${Elfutils_FIND_COMPONENTS} _tmp)
+  if(NOT ${_tmp} STREQUAL "DEBUGINFOD")
+    message(FATAL "Unknown component: '${Elfutils_FIND_COMPONENTS}'")
+  endif()
+  find_package(LibDebuginfod ${Elfutils_FIND_VERSION} ${_exact} ${_required} ${_quiet})
+  set(_need_debuginfod TRUE)
+  unset(_tmp)
+endif()
+
+# Ensure that each component has the same version number
+set(_versions ${LibDW_VERSION} ${LibELF_VERSION} ${LibDebuginfod_VERSION})
+list(REMOVE_DUPLICATES _versions)
+list(LENGTH _versions _len)
+if(${_len} GREATER 1)
+  message(FATAL_ERROR "Elfutils: conflicting versions found: (${_versions})")
+endif()
+unset(_len)
+
+set(Elfutils_VERSION ${_versions})
+unset(_versions)
+
+include(FindPackageHandleStandardArgs)
+if(${_need_debuginfod})
+  find_package_handle_standard_args(
+    Elfutils
+    FOUND_VAR Elfutils_FOUND
+    REQUIRED_VARS LibDW_INCLUDE_DIRS LibDW_LIBRARIES LibELF_INCLUDE_DIRS LibELF_LIBRARIES
+                  LibDebuginfod_INCLUDE_DIRS LibDebuginfod_LIBRARIES
+    VERSION_VAR Elfutils_VERSION)
+else()
+  find_package_handle_standard_args(
+    Elfutils
+    FOUND_VAR Elfutils_FOUND
+    REQUIRED_VARS LibDW_INCLUDE_DIRS LibDW_LIBRARIES LibELF_INCLUDE_DIRS LibELF_LIBRARIES
+    VERSION_VAR Elfutils_VERSION)
+endif()
+
+if(Elfutils_FOUND)
+  set(Elfutils_INCLUDE_DIRS
+      ${LibDW_INCLUDE_DIRS} ${LibELF_INCLUDE_DIRS} ${LibDebuginfod_INCLUDE_DIRS}
+      CACHE PATH "")
+  mark_as_advanced(Elfutils_INCLUDE_DIRS)
+
+  set(Elfutils_LIBRARIES
+      ${LibDW_LIBRARIES} ${LibELF_LIBRARIES} ${LibDebuginfod_LIBRARIES}
+      CACHE PATH "")
+  mark_as_advanced(Elfutils_LIBRARIES)
+
+  mark_as_advanced(Elfutils_VERSION)
+
+  if(NOT TARGET Elfutils::Elfutils)
+    add_library(Elfutils::Elfutils INTERFACE IMPORTED)
+    target_link_libraries(Elfutils::Elfutils INTERFACE LibELF::LibELF LibDW::LibDW)
+    if(${_need_debuginfod})
+      target_link_libraries(Elfutils::Elfutils INTERFACE LibDebuginfod::LibDebuginfod)
+    endif()
+  endif()
+endif()
+
+unset(_exact)
+unset(_quiet)
+unset(_required)
+unset(_need_debuginfod)

--- a/cmake/Modules/FindLibDW.cmake
+++ b/cmake/Modules/FindLibDW.cmake
@@ -1,0 +1,140 @@
+#[=======================================================================[.rst:
+FindLibDW
+---------
+
+Find libdw, the elfutils library for DWARF data and ELF file or process inspection.
+
+Variables that affect this module
+
+``LibDW_NO_SYSTEM_PATHS``
+  If `True`, no system paths are searched.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target:
+
+``LibDW::LibDW``
+  The libdw library, if found.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``LibDW_INCLUDE_DIRS``
+  where to find libdw.h, etc.
+``LibDW_LIBRARIES``
+  the libraries to link against to use libdw.
+``LibDW_FOUND``
+  If false, do not try to use libdw.
+``LibDW_VERSION``
+  the version of the libdw library found
+
+#]=======================================================================]
+cmake_policy(SET CMP0074 NEW) # Use <Package>_ROOT
+
+if(LibDW_NO_SYSTEM_PATHS)
+  set(_find_path_args NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+endif()
+
+# There is no way to tell pkg-config to ignore directories, so disable it
+if(NOT LibDW_NO_SYSTEM_PATHS)
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    if(NOT "x${LibDW_FIND_VERSION}" STREQUAL "x")
+      set(_version ">=${LibDW_FIND_VERSION}")
+    endif()
+    if(LibDW_FIND_QUIETLY)
+      set(_quiet "QUIET")
+    endif()
+
+    pkg_check_modules(PC_LIBDW ${_quiet} "libdw${_version}")
+    unset(_version)
+    unset(_quiet)
+  endif()
+endif()
+
+if(PC_LIBDW_FOUND)
+  # FindPkgConfig sometimes gets the include dir wrong
+  if("x${PC_LIBDW_INCLUDE_DIRS}" STREQUAL "x")
+    pkg_get_variable(PC_LIBDW_INCLUDE_DIRS libdw includedir)
+  endif()
+
+  set(LibDW_INCLUDE_DIRS
+      ${PC_LIBDW_INCLUDE_DIRS}
+      CACHE PATH "")
+  set(LibDW_LIBRARIES
+      ${PC_LIBDW_LINK_LIBRARIES}
+      CACHE PATH "")
+  set(LibDW_VERSION
+      ${PC_LIBDW_VERSION}
+      CACHE STRING "")
+else()
+  find_path(
+    LibDW_INCLUDE_DIRS
+    NAMES libdw.h
+    PATH_SUFFIXES elfutils ${_find_path_args})
+
+  find_library(
+    LibDW_LIBRARIES
+    NAMES libdw dw
+    PATH_SUFFIXES elfutils ${_find_path_args})
+
+  if(EXISTS "${LibDW_INCLUDE_DIRS}/version.h")
+    file(STRINGS "${LibDW_INCLUDE_DIRS}/version.h" _version_line
+         REGEX "^#define _ELFUTILS_VERSION[ \t]+[0-9]+")
+    string(REGEX MATCH "[0-9]+" _version "${_version_line}")
+    if(NOT "x${_version}" STREQUAL "x")
+      set(LibDW_VERSION "0.${_version}")
+    endif()
+    unset(_version_line)
+    unset(_version)
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  LibDW
+  FOUND_VAR LibDW_FOUND
+  REQUIRED_VARS LibDW_LIBRARIES LibDW_INCLUDE_DIRS
+  VERSION_VAR LibDW_VERSION)
+
+if(LibDW_FOUND)
+  mark_as_advanced(LibDW_INCLUDE_DIRS)
+  mark_as_advanced(LibDW_LIBRARIES)
+  mark_as_advanced(LibDW_VERSION)
+
+  # Some platforms explicitly list libelf as a dependency, so separate it out
+  list(LENGTH LibDW_LIBRARIES _cnt)
+  if(${_cnt} GREATER 1)
+    foreach(_l ${LibDW_LIBRARIES})
+      if(${_l} MATCHES "libdw")
+        set(_libdw ${_l})
+      else()
+        list(APPEND _link_libs ${_l})
+      endif()
+    endforeach()
+  endif()
+  unset(_cnt)
+
+  if(NOT TARGET LibDW::LibDW)
+    add_library(LibDW::LibDW UNKNOWN IMPORTED)
+    set_target_properties(LibDW::LibDW PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                  "${LibDW_INCLUDE_DIRS}")
+
+    if(NOT "x${_link_libs}" STREQUAL "x")
+      set_target_properties(
+        LibDW::LibDW PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                                IMPORTED_LINK_DEPENDENT_LIBRARIES "${_link_libs}")
+      set(LibDW_LIBRARIES ${_libdw})
+      unset(_libdw)
+      unset(_link_libs)
+    endif()
+
+    set_target_properties(LibDW::LibDW PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                                                  IMPORTED_LOCATION "${LibDW_LIBRARIES}")
+  endif()
+endif()
+
+unset(_find_path_args)

--- a/cmake/Modules/FindLibELF.cmake
+++ b/cmake/Modules/FindLibELF.cmake
@@ -1,0 +1,123 @@
+#[=======================================================================[.rst:
+FindLibELF
+----------
+
+Find libelf, the elfutils library to read and write ELF files.
+
+Variables that affect this module
+
+``LibELF_NO_SYSTEM_PATHS``
+  If `True`, no system paths are searched.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target:
+
+``LibELF::LibELF``
+  The libelf library, if found.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``LibELF_INCLUDE_DIRS``
+  where to find libelf.h, etc.
+``LibELF_LIBRARIES``
+  the libraries to link against to use libelf.
+``LibELF_FOUND``
+  If false, do not try to use libelf.
+``LibELF_VERSION``
+  the version of the libelf library found
+
+#]=======================================================================]
+cmake_policy(SET CMP0074 NEW) # Use <Package>_ROOT
+
+if(LibELF_NO_SYSTEM_PATHS)
+  set(_find_path_args NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+endif()
+
+# There is no way to tell pkg-config to ignore directories, so disable it
+if(NOT LibELF_NO_SYSTEM_PATHS)
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    if(NOT "x${LibELF_FIND_VERSION}" STREQUAL "x")
+      set(_version ">=${LibELF_FIND_VERSION}")
+    endif()
+    if(LibELF_FIND_QUIETLY)
+      set(_quiet "QUIET")
+    endif()
+
+    pkg_check_modules(PC_LIBELF ${_quiet} "libelf${_version}")
+    unset(_version)
+    unset(_quiet)
+  endif()
+endif()
+
+if(PC_LIBELF_FOUND)
+  # FindPkgConfig sometimes gets the include dir wrong
+  if("x${PC_LIBELF_INCLUDE_DIRS}" STREQUAL "x")
+    pkg_get_variable(PC_LIBELF_INCLUDE_DIRS libelf includedir)
+  endif()
+
+  set(LibELF_INCLUDE_DIRS
+      ${PC_LIBELF_INCLUDE_DIRS}
+      CACHE PATH "")
+  set(LibELF_LIBRARIES
+      ${PC_LIBELF_LINK_LIBRARIES}
+      CACHE PATH "")
+  set(LibELF_VERSION
+      ${PC_LIBELF_VERSION}
+      CACHE STRING "")
+else()
+  find_path(
+    LibELF_INCLUDE_DIRS
+    NAMES libelf.h
+    PATH_SUFFIXES elfutils ${_find_path_args})
+
+  find_library(
+    LibELF_LIBRARIES
+    NAMES libelf elf
+    PATH_SUFFIXES elfutils ${_find_path_args})
+
+  macro(_check_libelf_version _file)
+    file(STRINGS ${_file} _version_line REGEX "^#define _ELFUTILS_VERSION[ \t]+[0-9]+")
+    string(REGEX MATCH "[0-9]+" _version "${_version_line}")
+    if(NOT "x${_version}" STREQUAL "x")
+      set(LibELF_VERSION "0.${_version}")
+    endif()
+    unset(_version_line)
+    unset(_version)
+  endmacro()
+
+  if(EXISTS "${LibELF_INCLUDE_DIRS}/version.h")
+    _check_libelf_version("${LibELF_INCLUDE_DIRS}/version.h")
+  elseif(EXISTS "${LibELF_INCLUDE_DIRS}/elfutils/version.h")
+    _check_libelf_version("${LibELF_INCLUDE_DIRS}/elfutils/version.h")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  LibELF
+  FOUND_VAR LibELF_FOUND
+  REQUIRED_VARS LibELF_LIBRARIES LibELF_INCLUDE_DIRS
+  VERSION_VAR LibELF_VERSION)
+
+if(LibELF_FOUND)
+  mark_as_advanced(LibELF_INCLUDE_DIRS)
+  mark_as_advanced(LibELF_LIBRARIES)
+  mark_as_advanced(LibELF_VERSION)
+
+  if(NOT TARGET LibELF::LibELF)
+    add_library(LibELF::LibELF UNKNOWN IMPORTED)
+    set_target_properties(
+      LibELF::LibELF
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LibELF_INCLUDE_DIRS}"
+                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                 IMPORTED_LOCATION "${LibELF_LIBRARIES}")
+  endif()
+endif()
+
+unset(_find_path_args)

--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -1,0 +1,35 @@
+#================================================================
+#
+# Configure elfutils
+#
+#   ----------------------------------------
+#
+# ElfUtils_ROOT_DIR - Location of elfutils installation
+#
+# The individual find-modules use the <Package>_ROOT convention
+# as the first location to search for the package. If the user
+# specifies ElfUtils_ROOT_DIR, we override the <Package>_ROOT
+# values and require that each package ignores system directories.
+# In effect, this forces the package search to find only
+# candidates in <Package>_ROOT or CMAKE_PREFIX_PATH.
+#
+#================================================================
+
+include_guard(GLOBAL)
+
+# elfutils is only available on Unixes; provide a dummy target on other platforms
+if(NOT UNIX)
+  if(NOT TARGET Elfutils::Elfutils)
+    add_library(Elfutils::ElfUtils INTERFACE)
+  endif()
+  return()
+endif()
+
+# We need >=0.186 because of NVIDIA line map extensions
+set(_min_version 0.186)
+
+if(ElfUtils_ROOT_DIR)
+  set(ElfUtils_NO_SYSTEM_PATHS ON)
+endif()
+
+find_package(Elfutils ${_min_version} REQUIRED)

--- a/dwarf/CMakeLists.txt
+++ b/dwarf/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(dwarf_includes includes.cpp)
 target_compile_options(dwarf_includes PRIVATE ${UNIT_TESTS_WARNING_FLAGS})
 target_include_directories(dwarf_includes PRIVATE ${UNIT_TESTS_INCLUDES})
 target_link_libraries(dwarf_includes PRIVATE Dyninst::symtabAPI)
+target_link_libraries(dwarf_includes PRIVATE Elfutils::Elfutils)
 target_include_directories(dwarf_includes PRIVATE "dwarf/h")
 
 add_test(NAME dwarf_includes COMMAND dwarf_includes)

--- a/elf/CMakeLists.txt
+++ b/elf/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(dynelf_includes includes.cpp)
 target_compile_options(dynelf_includes PRIVATE ${UNIT_TESTS_WARNING_FLAGS})
 target_include_directories(dynelf_includes PRIVATE ${UNIT_TESTS_INCLUDES})
 target_link_libraries(dynelf_includes PRIVATE Dyninst::symtabAPI)
+target_link_libraries(dynelf_includes PRIVATE Elfutils::Elfutils)
 target_include_directories(dynelf_includes PRIVATE "elf/h")
 
 add_test(NAME dynelf_includes COMMAND dynelf_includes)

--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -7,4 +7,3 @@ target_link_libraries(syscall_x86 PRIVATE Dyninst::instructionAPI)
 
 add_test(NAME instructionAPI_syscall_x86_32 COMMAND syscall_x86 "32")
 add_test(NAME instructionAPI_syscall_x86_64 COMMAND syscall_x86 "64")
-


### PR DESCRIPTION
This wasn't caught because all of the Dyninst containers have elfutils installed in /usr.