### PR TITLE
Add test for invalid instruction decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(unit-tests)
 
 find_package(Dyninst 13.0.0 REQUIRED COMPONENTS parseAPI instructionAPI)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(NOT DYNINST_SOURCE_TREE)
   message(FATAL_ERROR "Must specify DYNINST_SOURCE_TREE")
 endif()

--- a/instructionAPI/CMakeLists.txt
+++ b/instructionAPI/CMakeLists.txt
@@ -7,3 +7,11 @@ target_link_libraries(syscall_x86 PRIVATE Dyninst::instructionAPI)
 
 add_test(NAME instructionAPI_syscall_x86_32 COMMAND syscall_x86 "32")
 add_test(NAME instructionAPI_syscall_x86_64 COMMAND syscall_x86 "64")
+
+
+add_executable(invalid_insn invalid_instruction.cpp)
+target_compile_options(invalid_insn PRIVATE ${UNIT_TESTS_WARNING_FLAGS})
+target_include_directories(invalid_insn PRIVATE ${UNIT_TESTS_INCLUDES})
+target_link_libraries(invalid_insn PRIVATE Dyninst::instructionAPI)
+
+add_test(NAME invalid_insn COMMAND invalid_insn)

--- a/instructionAPI/invalid_instruction.cpp
+++ b/instructionAPI/invalid_instruction.cpp
@@ -1,0 +1,45 @@
+#include "InstructionDecoder.h"
+#include "Architecture.h"
+
+#include <array>
+#include <map>
+
+#include "InstructionDecoder.h"
+#include "Architecture.h"
+
+#include <array>
+#include <map>
+
+int main() {
+  std::array<const unsigned char, 2> opcode = {
+    0x0f, 0x24
+  };
+
+  auto names = std::map<Dyninst::Architecture, char const*> {
+
+    // x86 incorrectly decodes this as 'mov %tr0,(%eax)'. tr0 isn't a valid register.
+//    { Dyninst::Arch_x86, "x86" },
+//    { Dyninst::Arch_x86_64, "x86_64" },
+
+    // ppc64 doesn't check the input size, so reads off the end of the array
+//    { Dyninst::Arch_ppc64, "ppc64" },
+
+    // aarch64 doesn't check the input size, so reads off the end of the array
+//    { Dyninst::Arch_aarch64, "aarch64" }
+  };
+
+  for(auto [arch, name] : names) {
+    Dyninst::InstructionAPI::InstructionDecoder dec(opcode.data(), opcode.size(), arch);
+    auto insn = dec.decode();
+
+    if(insn.isLegalInsn() != insn.isValid()) {
+      std::cerr << name << ": mismatched result for 'isLegalInsn' and 'isValid'\n";
+      return EXIT_FAILURE;
+    }
+
+    if(insn.isValid()) {
+      std::cerr << name << " decoded an invalid instruction as '" << insn.format() << "'\n";
+      return EXIT_FAILURE;
+    }
+  }
+}


### PR DESCRIPTION
None of x86, x86_64, ppc64, or aarch64 passes this test.